### PR TITLE
queryRecursiveConfirm message fix

### DIFF
--- a/app/nl/surfnet/safnari/QueryRecursiveStateMachine.scala
+++ b/app/nl/surfnet/safnari/QueryRecursiveStateMachine.scala
@@ -132,6 +132,7 @@ class QueryRecursiveStateMachine(
         .withSchedule(initialReserve.body.criteria.getSchedule())
         .withServiceType(initialReserve.body.criteria.getServiceType())
         .withVersion(initialReserve.body.criteria.getVersion())
+        .withAny(initialReserve.body.criteria.getAny())
         .withChildren(new ChildRecursiveListType().withChild(childs.asJava)))
   }
 


### PR DESCRIPTION
nsi-safnari was not populating the p2ps element associated with its service entry in the criteria element of the queryRecursiveConfirmed.  This p2ps element was held in an Any structure that was not being copied into the queryRecursiveConfirm from the original reservation.   Simply added copy and issue is fixed.  Closed issue #18.