### PR TITLE
Make a safe default configuration for the database

### DIFF
--- a/charts/nsi-safnari/Chart.yaml
+++ b/charts/nsi-safnari/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.2
+version: 1.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nsi-safnari/values.yaml
+++ b/charts/nsi-safnari/values.yaml
@@ -96,6 +96,8 @@ postgresql:
   postgresqlUsername: nsi-safnari-user
   postgresqlPassword:
   postgresqlDatabase: nsi-safnari
+  postgresqlConfiguration:
+    listenAddresses: '*'
   image:
     tag: 9.6.21
   persistence:


### PR DESCRIPTION
Postgres needs to listen on all ip addresses. In some versions of the bitnami container this is not explicitly set.